### PR TITLE
update broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Example template:
 var popupTemplate = "<h4>Hello {{name}}</h4>"
 ```
 
-#### Source from the [map demo](/demos/demo-map.html):
+#### Source from the [map demo](https://github.com/jlord/sheetsee.js/blob/master/demos/demo-map.html):
 
 ```JavaScript
 <script type="text/javascript">


### PR DESCRIPTION
In 

https://github.com/jlord/sheetsee-maps/blob/master/README.md
#### Source from the [map demo](/demos/demo-map.html):

Link is broken; should be changed to

https://github.com/jlord/sheetsee.js/blob/master/demos/demo-map.html
