### PR TITLE
Adds marker clustering option as parameter to addMarkerLayer

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ function mustachify(array) {
   return newArray
 }
 
-module.exports.addMarkerLayer = function(geoJSON, map, template) {
+module.exports.addMarkerLayer = function(geoJSON, map, template, clusterMarkers) {
   if (!template) {
     template = makePopupTemplate(geoJSON)
     ich.addTemplate(template.name, template.template)
@@ -192,12 +192,28 @@ module.exports.addMarkerLayer = function(geoJSON, map, template) {
     style: function(feature) { return feature.properties }
   })
   var bounds = layer.getBounds()
-  layer.addTo(map)
+
+  // check option and Leaflet extension
+  var cluster = clusterMarkers && 'MarkerClusterGroup' in L
+  if (cluster) {
+    var clusterGroup = new L.MarkerClusterGroup()
+  }
+
   map.fitBounds(bounds)
 
   layer.eachLayer(function(marker) {
     var popupContent = ich[template.name](marker.feature.opts)
     marker.bindPopup(popupContent.html(), {closeButton: false})
+    if (cluster) {
+      clusterGroup.addLayer(marker)
+    }
   })
+
+  if (cluster) {
+    map.addLayer(clusterGroup)
+  } else {
+    layer.addTo(map)
+  }
+
   return layer
 }


### PR DESCRIPTION
Per #6 and [this issue on the sheetsee.js repo](https://github.com/jlord/sheetsee.js/issues/71)

Clustering will be supported if both `clusterMarkers` is `true` and if Leaflet's marker clustering library is available.

I tested this on a project I'm currently working on in development and it seems to work fine and perform well, but it might need some tweaking to match conventions and other expectations. 💁

Thanks for all your work with sheetsee, @jlord! It's a great resource. 👏🙌 I hope this contribution helps.
